### PR TITLE
Add php-7.3, enhance composer command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 before_install:
-  - composer install --dev --ignore-platform-reqs
+  - composer install
 
 script:
   - mkdir -p build/logs


### PR DESCRIPTION
# Changed log
- Add `php-7.3` test during Travis CI build.
- The `--dev` option is for `composer install` is deprecated. Removing this option instead.

```
php ~/composer.phar install --dev
You are using the deprecated option "dev". Dev packages are installed by default now.
```
- Removing `--ignore-platform-reqs` option because it should check the environment to avoid unexpected environment issue during Travis CI build.